### PR TITLE
Ortografía fahrenheit

### DIFF
--- a/temperature.js
+++ b/temperature.js
@@ -28,7 +28,7 @@ function calculate() {
     num = parseFloat(num);
     if (type == 'c' || type == 'C') {
       result = (num * 9/5)+32;
-      result = result.toFixed(1)+" Farenheit";
+      result = result.toFixed(1)+" Fahrenheit";
     }
     else {
       result = (num - 32)*5/9;


### PR DESCRIPTION
La palabra fahrenheit estaba mal escrita en temperature.js
